### PR TITLE
get FullScreenshot

### DIFF
--- a/fixtures/scroll.html
+++ b/fixtures/scroll.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <style>
         button {

--- a/page_test.go
+++ b/page_test.go
@@ -331,13 +331,13 @@ func (s *S) TestPageScreenshot() {
 
 func (s *S) TestFullPageScreenshot() {
 	f := filepath.Join("tmp", kit.RandString(8)+".png")
-	p := s.page.Navigate(srcFile("fixtures/click.html"))
+	p := s.page.Navigate(srcFile("fixtures/scroll.html"))
 	p.FullScreenshot()
 	data := p.FullScreenshot(f)
 	img, err := png.Decode(bytes.NewBuffer(data))
 	kit.E(err)
 	s.Equal(1920, img.Bounds().Dx())
-	s.Equal(600, img.Bounds().Dy())
+	s.Equal(8018, img.Bounds().Dy())
 	s.FileExists(f)
 
 	kit.E(kit.Remove(slash("tmp/screenshots")))

--- a/page_test.go
+++ b/page_test.go
@@ -346,8 +346,9 @@ func (s *S) TestFullPageScreenshot() {
 	data := p.FullScreenshot(f)
 	img, err := png.Decode(bytes.NewBuffer(data))
 	kit.E(err)
-	s.Equal(8058, img.Bounds().Dx())
-	s.Equal(8034, img.Bounds().Dy())
+	res := p.Eval(`() => ({w: document.documentElement.scrollWidth, h: document.documentElement.scrollHeight})`)
+	s.Equal(int(res.Get("w").Int()), img.Bounds().Dx())
+	s.Equal(int(res.Get("h").Int()), img.Bounds().Dy())
 	s.FileExists(f)
 
 	kit.E(kit.Remove(slash("tmp/screenshots")))

--- a/page_test.go
+++ b/page_test.go
@@ -329,14 +329,30 @@ func (s *S) TestPageScreenshot() {
 	s.Len(kit.Walk(slash("tmp/screenshots/*")).MustList(), 1)
 }
 
-func (s *S) TestFullPageScreenshot() {
+func (s *S) TestFullPageScreenshotHD() {
 	f := filepath.Join("tmp", kit.RandString(8)+".png")
 	p := s.page.Navigate(srcFile("fixtures/scroll.html"))
-	p.FullScreenshot()
-	data := p.FullScreenshot(f)
+	p.FullScreenshot(true)
+	data := p.FullScreenshot(true, f)
 	img, err := png.Decode(bytes.NewBuffer(data))
 	kit.E(err)
 	s.Equal(1920, img.Bounds().Dx())
+	s.Equal(8018, img.Bounds().Dy())
+	s.FileExists(f)
+
+	kit.E(kit.Remove(slash("tmp/screenshots")))
+	p.Screenshot("")
+	s.Len(kit.Walk(slash("tmp/screenshots/*")).MustList(), 1)
+}
+
+func (s *S) TestFullPageScreenshotNotHD() {
+	f := filepath.Join("tmp", kit.RandString(8)+".png")
+	p := s.page.Navigate(srcFile("fixtures/scroll.html"))
+	p.FullScreenshot(false)
+	data := p.FullScreenshot(false, f)
+	img, err := png.Decode(bytes.NewBuffer(data))
+	kit.E(err)
+	s.Equal(768, img.Bounds().Dx())
 	s.Equal(8018, img.Bounds().Dy())
 	s.FileExists(f)
 

--- a/page_test.go
+++ b/page_test.go
@@ -329,31 +329,15 @@ func (s *S) TestPageScreenshot() {
 	s.Len(kit.Walk(slash("tmp/screenshots/*")).MustList(), 1)
 }
 
-func (s *S) TestFullPageScreenshotHD() {
+func (s *S) TestFullPageScreenshot() {
 	f := filepath.Join("tmp", kit.RandString(8)+".png")
 	p := s.page.Navigate(srcFile("fixtures/scroll.html"))
-	p.FullScreenshot(true)
-	data := p.FullScreenshot(true, f)
+	p.FullScreenshot()
+	data := p.FullScreenshot(f)
 	img, err := png.Decode(bytes.NewBuffer(data))
 	kit.E(err)
-	s.Equal(1920, img.Bounds().Dx())
-	s.Equal(8018, img.Bounds().Dy())
-	s.FileExists(f)
-
-	kit.E(kit.Remove(slash("tmp/screenshots")))
-	p.Screenshot("")
-	s.Len(kit.Walk(slash("tmp/screenshots/*")).MustList(), 1)
-}
-
-func (s *S) TestFullPageScreenshotNotHD() {
-	f := filepath.Join("tmp", kit.RandString(8)+".png")
-	p := s.page.Navigate(srcFile("fixtures/scroll.html"))
-	p.FullScreenshot(false)
-	data := p.FullScreenshot(false, f)
-	img, err := png.Decode(bytes.NewBuffer(data))
-	kit.E(err)
-	s.Equal(768, img.Bounds().Dx())
-	s.Equal(8018, img.Bounds().Dy())
+	s.Equal(8058, img.Bounds().Dx())
+	s.Equal(8034, img.Bounds().Dy())
 	s.FileExists(f)
 
 	kit.E(kit.Remove(slash("tmp/screenshots")))

--- a/page_test.go
+++ b/page_test.go
@@ -329,6 +329,22 @@ func (s *S) TestPageScreenshot() {
 	s.Len(kit.Walk(slash("tmp/screenshots/*")).MustList(), 1)
 }
 
+func (s *S) TestFullPageScreenshot() {
+	f := filepath.Join("tmp", kit.RandString(8)+".png")
+	p := s.page.Navigate(srcFile("fixtures/click.html"))
+	p.FullScreenshot()
+	data := p.FullScreenshot(f)
+	img, err := png.Decode(bytes.NewBuffer(data))
+	kit.E(err)
+	s.Equal(1920, img.Bounds().Dx())
+	s.Equal(600, img.Bounds().Dy())
+	s.FileExists(f)
+
+	kit.E(kit.Remove(slash("tmp/screenshots")))
+	p.Screenshot("")
+	s.Len(kit.Walk(slash("tmp/screenshots/*")).MustList(), 1)
+}
+
 func (s *S) TestPageInput() {
 	p := s.page.Navigate(srcFile("fixtures/input.html"))
 

--- a/sugar.go
+++ b/sugar.go
@@ -219,7 +219,7 @@ func (p *Page) FullScreenshot(toFile ...string) []byte {
 	p.WaitLoad()
 	res, err := proto.PageGetLayoutMetrics{}.Call(p)
 	kit.E(err)
-	p.Viewport(int64(res.ContentSize.Width), int64(res.ContentSize.Height), 1, false)
+	defer p.Viewport(int64(res.ContentSize.Width), int64(res.ContentSize.Height), 1, false)
 	bin := p.Screenshot(toFile...)
 	return bin
 }

--- a/sugar.go
+++ b/sugar.go
@@ -221,12 +221,14 @@ func (p *Page) Screenshot(toFile ...string) []byte {
 }
 
 // FullScreenshot gets the full height of the page and returns the binary of the image.
-// Uses an internal JavaScript function to get the client height.
+// Returns to original viewport after screenshot.
 func (p *Page) FullScreenshot(toFile ...string) []byte {
 	p.WaitLoad()
+	view := p.GetViewport()
+	defer p.Viewport(view.Width, view.Height, view.Scale, false)
 	res, err := proto.PageGetLayoutMetrics{}.Call(p)
 	kit.E(err)
-	defer p.Viewport(int64(res.ContentSize.Width), int64(res.ContentSize.Height), 1, false)
+	p.Viewport(int64(res.ContentSize.Width), int64(res.ContentSize.Height), 1, false)
 	bin := p.Screenshot(toFile...)
 	return bin
 }

--- a/sugar.go
+++ b/sugar.go
@@ -215,14 +215,11 @@ func (p *Page) Screenshot(toFile ...string) []byte {
 
 // FullScreenshot gets the full height of the page and returns the binary of the image.
 // Uses an internal JavaScript function to get the client height.
-func (p *Page) FullScreenshot(fullHD bool, toFile ...string) []byte {
+func (p *Page) FullScreenshot(toFile ...string) []byte {
 	p.WaitLoad()
-	size := p.Eval(`() => ({w: document.body.clientWidth, h: document.body.clientHeight})`)
-	if fullHD {
-		p.Viewport(1920, size.Get("h").Int(), 1, false)
-	} else {
-		p.Viewport(size.Get("w").Int(), size.Get("h").Int(), 1, false)
-	}
+	res, err := proto.PageGetLayoutMetrics{}.Call(p)
+	kit.E(err)
+	p.Viewport(int64(res.ContentSize.Width), int64(res.ContentSize.Height), 1, false)
 	bin, err := p.ScreenshotE(&proto.PageCaptureScreenshot{})
 	kit.E(err)
 	kit.E(saveScreenshot(bin, toFile))

--- a/sugar.go
+++ b/sugar.go
@@ -217,6 +217,7 @@ func (p *Page) Screenshot(toFile ...string) []byte {
 // FullScreenshot gets the full height of the page and returns the binary of the image.
 // Uses an internal JavaScript function to get the client height.
 func (p *Page) FullScreenshot(toFile ...string) []byte {
+	p.WaitLoad()
 	height := p.Eval(`() => document.body.clientHeight`).String()
 	heightToInt, err := strconv.ParseInt(height, 10, 64)
 	kit.E(err)

--- a/sugar.go
+++ b/sugar.go
@@ -220,9 +220,7 @@ func (p *Page) FullScreenshot(toFile ...string) []byte {
 	res, err := proto.PageGetLayoutMetrics{}.Call(p)
 	kit.E(err)
 	p.Viewport(int64(res.ContentSize.Width), int64(res.ContentSize.Height), 1, false)
-	bin, err := p.ScreenshotE(&proto.PageCaptureScreenshot{})
-	kit.E(err)
-	kit.E(saveScreenshot(bin, toFile))
+	bin := p.Screenshot(toFile...)
 	return bin
 }
 

--- a/sugar.go
+++ b/sugar.go
@@ -5,6 +5,7 @@ package rod
 import (
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/ysmood/kit"
@@ -207,6 +208,19 @@ func (p *Page) GetDownloadFile(pattern string) (wait func() (http.Header, []byte
 // Screenshot the page and returns the binary of the image
 // If the toFile is "", it will save output to "tmp/screenshots" folder, time as the file name.
 func (p *Page) Screenshot(toFile ...string) []byte {
+	bin, err := p.ScreenshotE(&proto.PageCaptureScreenshot{})
+	kit.E(err)
+	kit.E(saveScreenshot(bin, toFile))
+	return bin
+}
+
+// FullScreenshot gets the full height of the page and returns the binary of the image.
+// Uses an internal JavaScript function to get the client height.
+func (p *Page) FullScreenshot(toFile ...string) []byte {
+	height := p.Eval(`() => document.body.clientHeight`).String()
+	heightToInt, err := strconv.ParseInt(height, 10, 64)
+	kit.E(err)
+	p.Viewport(1920, heightToInt, 1, false)
 	bin, err := p.ScreenshotE(&proto.PageCaptureScreenshot{})
 	kit.E(err)
 	kit.E(saveScreenshot(bin, toFile))

--- a/sugar.go
+++ b/sugar.go
@@ -5,7 +5,6 @@ package rod
 import (
 	"net/http"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/ysmood/kit"
@@ -216,12 +215,14 @@ func (p *Page) Screenshot(toFile ...string) []byte {
 
 // FullScreenshot gets the full height of the page and returns the binary of the image.
 // Uses an internal JavaScript function to get the client height.
-func (p *Page) FullScreenshot(toFile ...string) []byte {
+func (p *Page) FullScreenshot(fullHD bool, toFile ...string) []byte {
 	p.WaitLoad()
-	height := p.Eval(`() => document.body.clientHeight`).String()
-	heightToInt, err := strconv.ParseInt(height, 10, 64)
-	kit.E(err)
-	p.Viewport(1920, heightToInt, 1, false)
+	size := p.Eval(`() => ({w: document.body.clientWidth, h: document.body.clientHeight})`)
+	if fullHD {
+		p.Viewport(1920, size.Get("h").Int(), 1, false)
+	} else {
+		p.Viewport(size.Get("w").Int(), size.Get("h").Int(), 1, false)
+	}
 	bin, err := p.ScreenshotE(&proto.PageCaptureScreenshot{})
 	kit.E(err)
 	kit.E(saveScreenshot(bin, toFile))


### PR DESCRIPTION
As for now, the function might work as checking the full clientHeight,
parsing it as an integer, setting the viewport (might be a good idea to
lose hardcoded "1920" in favour of clientWidth or a flag making in HD,
don't know yet) and then getting the screenshot and saving it.

Few issues with this solution:
* Maybe there's a better way of evaluating the JavaScript
* Maybe there's no need to evaluate it whatsoever
* What happens with the viewport after the screenshot has been made?
  Right now it will be morphed to a full height of the page.

Will keep working on it as I have to explore the library a bit more.

Referencing #32 .